### PR TITLE
Revert "build: Add shared-modules/gudev"

### DIFF
--- a/io.github.sharkwouter.Minigalaxy.yaml
+++ b/io.github.sharkwouter.Minigalaxy.yaml
@@ -94,9 +94,6 @@ modules:
               version-pattern: <link>https://www.boost.org/users/history/version_([\d_]+).html</link>
               url-template: https://boostorg.jfrog.io/artifactory/main/release/$version0.$version2.$version4/source/boost_$version.tar.bz2
 
-  # Shared modules
-  - shared-modules/gudev/gudev.json
-
   - name: bundle-setup
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This reverts commit 6f4345be3fdc47f65c2e56cbbd8e20a7d2f4db7e.

The proper fix landed in:
https://github.com/flathub/org.winehq.Wine/commit/f481295ee99f6a8f1f3e846bd26d854166098411