### PR TITLE
Remove incompatible runtime extension (Fixes #61)

### DIFF
--- a/io.github.sharkwouter.Minigalaxy.yaml
+++ b/io.github.sharkwouter.Minigalaxy.yaml
@@ -23,7 +23,6 @@ inherit-extensions:
   - org.freedesktop.Platform.ffmpeg_full.i386
   - org.freedesktop.Platform.ffmpeg-full
   - org.freedesktop.Platform.GL32
-  - org.freedesktop.Platform.VAAPI.Intel.i386
   - org.winehq.Wine.DLLs
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono


### PR DESCRIPTION
**org.freedesktop.Platform.VAAPI.Intel.i386** is incompatible with **org.gnome.Platform.Compat.i386** because the latter is missing the directory _dri/intel-vaapi-driver_.