### PR TITLE
Fix: Allow creating desktop shortcuts in Flatpak version

### DIFF
--- a/io.github.sharkwouter.Minigalaxy.yaml
+++ b/io.github.sharkwouter.Minigalaxy.yaml
@@ -46,6 +46,7 @@ finish-args:
   - --env=WINEESYNC=1
   - --env=WINEFSYNC=1
   - --filesystem=~/GOG Games:create
+  - --filesystem=xdg-data/applications
   - --persist=.
   - --share=ipc
   - --share=network


### PR DESCRIPTION
This pull request adds the **--filesystem=xdg-data/application**s entry to the Flatpak manifest (io.github.sharkwouter.Minigalaxy.yaml). This allows the Flatpak version of Minigalaxy to create desktop shortcuts in the user's ~/.local/share/applications/ directory, resolving a FileNotFoundError that prevented shortcut creation during game installation.

The missing permission was identified by GB609 on the Minigalaxy forum.