### PR TITLE
Update libraries and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/**

--- a/addons/scummvm.json
+++ b/addons/scummvm.json
@@ -3,8 +3,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://downloads.scummvm.org/frs/scummvm/2.6.0/scummvm-2.6.0.tar.bz2",
-            "sha256": "d4eaf02e592a1b100d0d59ecf248541e8219252769777efeea182ca7dac4c519"
+            "url": "https://downloads.scummvm.org/frs/scummvm/2.9.0/scummvm-2.9.0.tar.bz2",
+            "sha256": "9bfb67083524bbe48d56e1ce9cfae8af73817909fcc3d938a550c031aaaa23e5"
         }
     ],
     "config-opts": [
@@ -15,11 +15,12 @@
     "../shared-modules/libmad/libmad.json",
     {
         "name": "faad2",
+        "buildsystem": "cmake-ninja",
         "sources": [
             {
                 "type": "archive",
-                "url": "https://sourceforge.net/projects/faac/files/faad2-src/faad2-2.8.0/faad2-2.8.8.tar.gz",
-                "sha256": "985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d"
+                "url": "https://github.com/knik0/faad2/archive/refs/tags/2.11.2.tar.gz",
+                "sha256": "3fcbd305e4abd34768c62050e18ca0986f7d9c5eca343fb98275418013065c0e"
             }
         ]
     },

--- a/generated/libs.json
+++ b/generated/libs.json
@@ -12,8 +12,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/freeglut/freeglut/3.2.1/freeglut-3.2.1.tar.gz",
-                    "sha256": "d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68"
+                    "url": "https://github.com/freeglut/freeglut/releases/download/v3.6.0/freeglut-3.6.0.tar.gz",
+                    "sha256": "9c3d4d6516fbfa0280edc93c77698fb7303e443c1aaaf37d269e3288a6c3ea52"
                 }
             ]
         },
@@ -41,8 +41,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/freeglut/freeglut/3.2.1/freeglut-3.2.1.tar.gz",
-                    "sha256": "d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68"
+                    "url": "https://github.com/freeglut/freeglut/releases/download/v3.6.0/freeglut-3.6.0.tar.gz",
+                    "sha256": "9c3d4d6516fbfa0280edc93c77698fb7303e443c1aaaf37d269e3288a6c3ea52"
                 }
             ],
             "only-arches": [
@@ -190,8 +190,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.2.tar.xz",
-                    "sha256": "c8bee4790d9058bacc4b6246456c58021db58a87ddda1a9d0139bf5f18f1f240"
+                    "url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.3.tar.xz",
+                    "sha256": "f8dd7566adb74147fab9964680b6bbadee87cf406a7fcff51718a5e6949b841c"
                 }
             ]
         },
@@ -200,8 +200,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.2.tar.xz",
-                    "sha256": "c8bee4790d9058bacc4b6246456c58021db58a87ddda1a9d0139bf5f18f1f240"
+                    "url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.3.tar.xz",
+                    "sha256": "f8dd7566adb74147fab9964680b6bbadee87cf406a7fcff51718a5e6949b841c"
                 }
             ],
             "only-arches": [

--- a/generated/pypi-dependencies.json
+++ b/generated/pypi-dependencies.json
@@ -7,28 +7,28 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl",
-            "sha256": "92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
+            "url": "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl",
+            "sha256": "ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz",
-            "sha256": "63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"
+            "url": "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl",
+            "sha256": "d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
-            "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
-            "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+            "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
+            "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/26/40/9957270221b6d3e9a3b92fdfba80dd5c9661ff45a664b47edd5d00f707f5/urllib3-2.0.6-py3-none-any.whl",
-            "sha256": "7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"
+            "url": "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl",
+            "sha256": "1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"
         }
     ]
 }

--- a/generated/shared-modules.json
+++ b/generated/shared-modules.json
@@ -221,7 +221,10 @@
                         },
                         {
                             "type": "patch",
-                            "path": "../shared-modules/gtk2/gtk2-fix-crash-in-show-uri.patch"
+                            "paths": [
+                                "../shared-modules/gtk2/gtk2-fix-crash-in-show-uri.patch",
+                                "../shared-modules/gtk2/gtk2-gcc14.patch"
+                            ]
                         }
                     ]
                 },
@@ -370,7 +373,10 @@
                         },
                         {
                             "type": "patch",
-                            "path": "../shared-modules/gtk2/gtk2-fix-crash-in-show-uri.patch"
+                            "paths": [
+                                "../shared-modules/gtk2/gtk2-fix-crash-in-show-uri.patch",
+                                "../shared-modules/gtk2/gtk2-gcc14.patch"
+                            ]
                         }
                     ],
                     "only-arches": [

--- a/io.github.sharkwouter.Minigalaxy.yaml
+++ b/io.github.sharkwouter.Minigalaxy.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.sharkwouter.Minigalaxy
 runtime: org.gnome.Platform
-runtime-version: &runtime-version '46'
+runtime-version: &runtime-version '48'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.gnome.Sdk.Compat.i386

--- a/modules/libs.yml
+++ b/modules/libs.yml
@@ -9,8 +9,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/freeglut/freeglut/3.2.1/freeglut-3.2.1.tar.gz
-        sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
+        url: https://github.com/freeglut/freeglut/releases/download/v3.6.0/freeglut-3.6.0.tar.gz
+        sha256: 9c3d4d6516fbfa0280edc93c77698fb7303e443c1aaaf37d269e3288a6c3ea52
 
   - name: libcaca
     config-opts:
@@ -38,5 +38,5 @@ modules:
   - name: xrandr
     sources:
       - type: archive
-        url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.2.tar.xz
-        sha256: c8bee4790d9058bacc4b6246456c58021db58a87ddda1a9d0139bf5f18f1f240
+        url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.3.tar.xz
+        sha256: f8dd7566adb74147fab9964680b6bbadee87cf406a7fcff51718a5e6949b841c


### PR DESCRIPTION
This is the promised follow-up on #84. I have updated anything i could find.

Small side note: I think the file `pypi-dependencies.json` shouldn't be in the `generated` sub-directory because it actually is neither touched nor generated by `multilibify` in `make`. However, `make clean` unconditionally executes `rm generated/*` which then also deletes the unrelated pypi-dependencies.json.

Version changes and checks i made:
- GNOME platform: 46 -> 48
- freeglut: 3.2.1 -> 3.6.0
- libcaca: most recent (0.99.beta20) has compile errors, keep 0.99.beta19
- libbsd: no updates available
- xrandr: 1.5.2 -> 1.5.3
- ScummVM: 2.6.0 -> 2.9.0
- ScummVM dependency faad2: 2.8.0 -> 2.11.2
- Dosbox-staging: Nothing new available
- update PyPi dependencies:
  * certifi: 2023.7.22 -> 2025.1.31
  * charset_normalizer: 3.3.0 -> 3.4.1
  * idna: 3.4 -> 3.10
  * requests: 2.31.0 -> 2.32.2
  * urllib3: 2.0.6 -> 2.3.0

- update commit id of shared-modules submodule

also added .flatpak-builder to gitignore